### PR TITLE
fix a bug in DCGAN

### DIFF
--- a/dcgan/main.py
+++ b/dcgan/main.py
@@ -129,7 +129,7 @@ class _netG(nn.Module):
 
     def forward(self, input):
         gpu_ids = None
-        if isinstance(input.data, torch.cuda.FloatTensor) and self.ngpu > 1:
+        if isinstance(input.data, torch.cuda.FloatTensor) and self.ngpu >= 1:
             gpu_ids = range(self.ngpu)
         return nn.parallel.data_parallel(self.main, input, gpu_ids)
 
@@ -168,7 +168,7 @@ class _netD(nn.Module):
 
     def forward(self, input):
         gpu_ids = None
-        if isinstance(input.data, torch.cuda.FloatTensor) and self.ngpu > 1:
+        if isinstance(input.data, torch.cuda.FloatTensor) and self.ngpu > =1:
             gpu_ids = range(self.ngpu)
         output = nn.parallel.data_parallel(self.main, input, gpu_ids)
         return output.view(-1, 1)


### PR DESCRIPTION
Using single GPU in DCGAN caused an error because  'gpu_ids'  in forward function will be None .